### PR TITLE
Remove _compact function.

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,9 +17,13 @@
             var self = this;
             Object.keys(this._embedded).forEach(function(key) {
                 if (self._embedded.hasOwnProperty(key)) {
+                  if (Array.isArray(self._embedded[key])) {
                     _embedded[key] = [].concat(self._embedded[key]).map(function(embed) {
                         return createHALSONResource(embed);
                     });
+                  } else {
+                    _embedded[key] = createHALSONResource(self._embedded[key]);
+                  }
                 }
             });
 

--- a/index.js
+++ b/index.js
@@ -26,38 +26,7 @@
             this._embedded = _embedded;
         }
 
-        this._compact('_embedded');
-        this._compact('_links');
     }
-
-    HALSONResource.prototype._compact = function(name, key) {
-        var target = this[name];
-
-        if (typeof target !== 'object') {
-            return;
-        }
-
-        var keys = key ? [key] : Object.keys(target);
-
-        keys.forEach(function(k) {
-            var items = target[k];
-            if (!Array.isArray(items)) {
-                return;
-            }
-
-            if (!items.length) {
-                delete(target[k]);
-            } else if (items.length === 1) {
-                target[k] = items[0];
-            }
-        });
-
-        if (!Object.keys(target).length) {
-            return delete this[name];
-        }
-
-        this[name] = target;
-    };
 
     HALSONResource.prototype.className = 'HALSONResource';
 
@@ -165,7 +134,6 @@
             Array.prototype.splice.apply(this._embedded[rel], params);
         }
 
-        this._compact('_embedded', rel);
         return this;
     };
 
@@ -180,7 +148,6 @@
             this._links[rel] = [].concat(this._links[rel]).filter(this._invert(filterCallback));
         }
 
-        this._compact('_links', rel);
         return this;
     };
 
@@ -194,7 +161,6 @@
         }
 
         this._embedded[rel] = [].concat(this._embedded[rel]).filter(this._invert(filterCallback));
-        this._compact('_embedded', rel);
 
         return this;
     };

--- a/test.js
+++ b/test.js
@@ -163,33 +163,6 @@ describe('halson', function() {
         });
     });
 
-    describe('_compact', function() {
-        it('ignore array with many elements', function(){
-            var res = halson(clone(example));
-            var expected = clone(example._embedded);
-            expect(res._embedded.starred).to.be.length(3);
-            res._compact('_embedded');
-            expect(res._embedded.starred).to.be.length(3);
-            assert.deepEqual(res._embedded, expected);
-        });
-
-        it('flatify array with one element', function(){
-            var res = halson(clone(example));
-            var tmp = clone(example._embedded).starred[0];
-            res._embedded.starred = [tmp];
-            expect(res._embedded.starred).to.be.length(1);
-            res._compact('_embedded');
-            assert.deepEqual(res._embedded.starred, tmp);
-        });
-
-        it('purge array with no elements', function(){
-            var res = halson();
-            res._embedded = {};
-            res._compact('_embedded');
-            expect(res._embedded).to.be.an('undefined');
-        });
-    });
-
     describe('listLinkRels()', function() {
         it('return empty list', function() {
             var res = halson().listLinkRels();
@@ -685,7 +658,7 @@ describe('halson', function() {
                 return item.name === 'twitter';
             });
             var expected = clone(example._links);
-            expected.related = expected.related[0];
+            expected.related = [expected.related[0]];
             assert.deepEqual(res._links, expected);
         });
     });


### PR DESCRIPTION
This is related to https://github.com/seznam/halson/issues/6 and a follow up to https://github.com/seznam/halson/pull/7.

The PR https://github.com/seznam/halson/pull/7 addresses single item array compact in the context of `HALSONResource.prototype.insertEmbed`. The behaviour was still present in the constructor `HALSONResource` because of the call to `_compact`. 

By removing the `_compact` feature altogether we observe the principle of least surprise and do not make assumptions or change the data representation that is passed into halson.
